### PR TITLE
Исправление примера конфига NGINX

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,11 +153,20 @@ KodiCMS основана на базе [Kohana framework](http://kohanaframework
 			include fastcgi_params;
 		}
 	
-		# Блокируем доступ для всех скрытых файлов,
-		# таких как .htaccess, .git, .svn и т.д.
-		location ~ /\.ht {
-			deny all;
-		}
+		# Блокируем доступ извне, к файлам и папкам:
+			# таким как .htaccess
+			location ~ /\.ht {
+				deny all;
+				return 404;
+			}
+
+			# а также каталогов .git, .svn
+			location ~.(git|svn) {
+	        	deny  all;
+	            return 404;
+	        }
+
+
 	}
 
 

--- a/README_EN.md
+++ b/README_EN.md
@@ -117,11 +117,18 @@ KodiCMS is a CMS based on [Kohana framework](http://kohanaframework.org/).
 			include fastcgi_params;
 		}
 	
-		# Блокируем доступ для всех скрытых файлов,
-		# таких как .htaccess, .git, .svn и т.д.
-		location ~ /\.ht {
-			deny all;
-		}
+		# Блокируем доступ извне, к файлам и папкам:
+			# таким как .htaccess
+			location ~ /\.ht {
+				deny all;
+				return 404;
+			}
+
+			# а также каталогов .git, .svn
+			location ~.(git|svn) {
+	        	deny  all;
+	            return 404;
+	        }
 	}
 
 


### PR DESCRIPTION
Описание этого блока не верное - он блокирует доступ только к файлам .ht\* и не более.

```
location ~ /\.ht {
deny all;
}
```

Для ограничение доступа к таким каталогам как .git, .svn, необходимо добавить дополнительный блок в конфигурации

```
location ~.(git|svn) {
deny  all;
return 404;
}
```

Также для скрытия факта существования файла/каталога, рекомендуется возвращать ошибку 404 а не 403 (которую вернёт обычный deny  all), при этом deny all оставить на всякий случай ;)
