### PR TITLE
Фикс пустого значения по умолчанию

### DIFF
--- a/cms/plugins/hybrid/classes/datasource/hybrid/field/source/document.php
+++ b/cms/plugins/hybrid/classes/datasource/hybrid/field/source/document.php
@@ -11,7 +11,7 @@
 class DataSource_Hybrid_Field_Source_Document extends DataSource_Hybrid_Field_Source_OneToOne {
 
 	protected $_is_searchable = FALSE;
-	
+	protected $default = 0;
 	protected $_props = array(
 		'isreq' => TRUE,
 		'ds_type' => NULL,


### PR DESCRIPTION
Система ругалась на невозможность создания такого поля с "пустым" значение по молчанию. Не знаю, насколько это "изящное" решение, но объявив здесь эту переменную теперь имеем "нуль" по умолчанию и все работает
